### PR TITLE
Add instructions for use with a shortcut on iOS/iPadOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
 							<li>Kiwi</li>
 							<li>Safari</li>
 							<li>Gnome Web</li>
-							<li>based on user report</li>
+							<li>with a <a href="#shortcut-install">shortcut</a></li>
 						</ol>
 						<svg>
 							<use xlink:href="#icon-extension"></use>
@@ -440,6 +440,19 @@
 					<button type="text" id="copy-bm" class="action-button">Copy bookmarklet code</button>
 					<pre class="card" id="content-bm"><code contenteditable>javascript:(()%3D%3E%7Bconst%20s%3Ddocument.createElement(%22script%22)%3Bs.async%3D!0%2Cs.src%3D%22https%3A%2F%2Fspelling-bee-assistant.app%2Fassets%2Fjs%2Fspelling-bee-assistant.min.js%22%2Cdocument.body.append(s)%3B%7D)()</code></pre>
 				</p>
+				<h3 id="shortcut-install">Install using Shortcuts</h3>
+				<p>In Safari on iOS and iPadOS, you can use a Shortcut to add Spelling Bee Assistant to the page. Here are the steps:</p>
+				<ol>
+					<li>Open the Settings app. Go to Shortcuts, then Advanced. Turn on "Allow Running Scripts". This allows shortcuts to run arbitrary scripts, 
+						including adding Spelling Bee Assistant's code to the Bee's webpage.</li>
+					<li>Open <a href="https://www.icloud.com/shortcuts/79d33cfa17a743d2b8d4cb4d80ebd22d">this link</a> to get the shortcut. Tap "Get Shortcut", then "Add".</li>
+					<li>Now the shortcut is saved to your device. To use it, start by opening Spelling Bee in Safari. (Only Safari will work here, Shortcuts don't work in other browsers. 
+						This is an Apple decision and not anything we can fix.)</li>
+					<li>Open the Share menu, then scroll down and find "SB Assistant". Tap it to run it.</li>
+					<li>The first time you run it, you'll get a security warning. Read it carefully, and if you understand it, tap Allow.</li>
+				</ol>
+				That's all! Now you have Spelling Bee Assistant on your iPhone or iPad. To pin it to the top of the share sheet, tap "Edit Actions...", 
+				then tap the green plus next to the SB Assistant action.
 				<h3>The above options aren’t working for me</h3>
 				<p>If you can’t use Spelling Bee Assistant, for instance, because you play on the NYT app or any other environment it
 					won’t run on, I suggest using <a href="https://www.sbsolver.com/" target="_blank" rel="noopener">W. Shunn’s
@@ -447,7 +460,7 @@
 			</section>
 			<section>
 				<h2>Doesn’t it spoil the game?</h2>
-				<p>I try to keep Spelling Bee Assistant as subtle and unobstrusive as possible. Judging from user feedback as well my own experience, this concept works out just fine.</p>
+				<p>I try to keep Spelling Bee Assistant as subtle and unobtrusive as possible. Judging from user feedback as well my own experience, this concept works out just fine.</p>
 				<p>The challenge stays the same and so does the fun. But now you have a set of little helpers at hand when you’re stuck in a corner.</p>
 			</section>
 			<section>


### PR DESCRIPTION
This adds instructions to use Assistant with a Shortcut on iOS/iPadOS. I've been using this method for a while and it works perfectly, so I figured I should share it.
